### PR TITLE
testing builds so why do it twice, remove build

### DIFF
--- a/.github/workflows/test_rust_workflow.yml
+++ b/.github/workflows/test_rust_workflow.yml
@@ -41,13 +41,13 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
-      - name: Build project quietly
-        uses: actions-rs/cargo@v1
-        env:
-          RUSTFLAGS: -Awarnings
-        with:
-          command: build
-          args: -q --no-default-features
+#       - name: Build project quietly
+#         uses: actions-rs/cargo@v1
+#         env:
+#           RUSTFLAGS: -Awarnings
+#         with:
+#           command: build
+#           args: -q --no-default-features
       - name: Run Tests
         uses: actions-rs/cargo@v1
         env:


### PR DESCRIPTION
This PR removes the build before the test, in CI CD, in order to improve CI times