### PR TITLE
Update Property and History APIs within the window views

### DIFF
--- a/raphtory/src/graph_window.rs
+++ b/raphtory/src/graph_window.rs
@@ -134,7 +134,7 @@ impl WindowedVertex {
 
 #[pymethods]
 impl WindowedVertex {
-    pub fn prop(&self, name: String) -> Vec<(i64, Prop)> {
+    pub fn property(&self, name: String) -> Vec<(i64, Prop)> {
         self.vertex_w
             .prop(name)
             .into_iter()
@@ -142,7 +142,7 @@ impl WindowedVertex {
             .collect_vec()
     }
 
-    pub fn props(&self) -> HashMap<String, Vec<(i64, Prop)>> {
+    pub fn properties(&self) -> HashMap<String, Vec<(i64, Prop)>> {
         self.vertex_w
             .props()
             .into_iter()
@@ -262,7 +262,16 @@ impl From<graph_window::WindowedEdge> for WindowedEdge {
 
 #[pymethods]
 impl WindowedEdge {
-    pub fn prop(&self, name: String) -> Vec<(i64, Prop)> {
+
+    pub fn src(&self) -> u64 {
+        self.edge_w.src
+    }
+
+    pub fn dst(&self) -> u64 {
+        self.edge_w.src
+    }
+
+    pub fn properties(&self, name: String) -> Vec<(i64, Prop)> {
         self.edge_w
             .prop(name)
             .into_iter()

--- a/raphtory/tests/notebook.ipynb
+++ b/raphtory/tests/notebook.ipynb
@@ -86,7 +86,7 @@
     "from raphtory import graph_gen\n",
     "\n",
     "g = Graph(4)\n",
-    "graph_gen.ba_preferential_attachment(g,vertices_to_add=100000,edges_per_step=10)\n",
+    "graph_gen.ba_preferential_attachment(g,vertices_to_add=1000,edges_per_step=10)\n",
     "view = g.window(0,1000)\n",
     "\n",
     "ids = []\n",
@@ -157,6 +157,62 @@
     "g.add_edge(40,10,12,{})\n",
     "\n",
     "v.vertex(10).degree()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Vertex 10 gained 3 connections in the second time window\n"
+     ]
+    }
+   ],
+   "source": [
+    "from raphtory import Graph\n",
+    "from raphtory import Perspective\n",
+    "from raphtory import graph_gen\n",
+    "\n",
+    "\n",
+    "g = Graph()\n",
+    "graph_gen.ba_preferential_attachment(g,vertices_to_add=1000,edges_per_step=10)\n",
+    "\n",
+    "perspective_set = Perspective.expanding(step=100)\n",
+    "views = g.through(perspective_set)\n",
+    "\n",
+    "first_view = next(views)\n",
+    "second_view = next(views)\n",
+    "\n",
+    "first_degree = first_view.vertex(10).degree()\n",
+    "second_degree = second_view.vertex(10).degree()\n",
+    "\n",
+    "print(\"Vertex 10 gained\",second_degree-first_degree,\"connections in the second time window\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "'builtins.WindowedVertices' object is not an iterator",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mTypeError\u001B[0m                                 Traceback (most recent call last)",
+      "Cell \u001B[0;32mIn[34], line 2\u001B[0m\n\u001B[1;32m      1\u001B[0m \u001B[39mfor\u001B[39;00m i \u001B[39min\u001B[39;00m pers:\n\u001B[0;32m----> 2\u001B[0m     \u001B[39mprint\u001B[39m(\u001B[39mnext\u001B[39;49m(i\u001B[39m.\u001B[39;49mvertices()))\n",
+      "\u001B[0;31mTypeError\u001B[0m: 'builtins.WindowedVertices' object is not an iterator"
+     ]
+    }
+   ],
+   "source": [
+    "for i in pers:\n",
+    "    print(next(i.vertices()))"
    ]
   },
   {

--- a/raphtory/tests/test_graphdb.py
+++ b/raphtory/tests/test_graphdb.py
@@ -247,8 +247,8 @@ def test_windowed_graph_vertex_prop():
 
     view = g.window(min_size, max_size)
 
-    assert view.vertex(1).prop("type") == [(0, 'wallet')]
-    assert view.vertex(1).prop("undefined") == []
+    assert view.vertex(1).property("type") == [(0, 'wallet')]
+    assert view.vertex(1).property("undefined") == []
 
 
 def test_windowed_graph_vertex_props():
@@ -259,7 +259,7 @@ def test_windowed_graph_vertex_props():
 
     view = g.window(min_size, max_size)
 
-    assert view.vertex(1).props() == {
+    assert view.vertex(1).properties() == {
         'cost': [(0, 99.5)], 'type': [(0, 'wallet')]}
 
 
@@ -273,9 +273,9 @@ def test_windowed_graph_edge_prop():
 
     edge = next(view.vertex(1).edges())
 
-    assert edge.prop("prop1") == [(0, 1), (1, 1)]
-    assert edge.prop("prop3") == [(0, 'test'), (1, 'test')]
-    assert edge.prop("undefined") == []
+    assert edge.properties("prop1") == [(0, 1), (1, 1)]
+    assert edge.properties("prop3") == [(0, 'test'), (1, 'test')]
+    assert edge.properties("undefined") == []
 
 
 def test_algorithms():


### PR DESCRIPTION
### What changes were proposed in this pull request?

**New semantics for property access**
- `property(name)` - Takes the name of the property you are interested in and returns the latest value within the bounds of the window
- `property_history(name)`  - Takes the name of the property you are interested in and returns the history within the bounds of the window (what our prop() function currently does)
- `properties()` - Returns the latest value for all properties as a dict
- `property_histories()` - Returns the full history of all properties within a dict
- `property_names()` - Returns all property keys the entity has within the window
- `has_property(name)` - Returns true if the entity has a value for this property within the window

**Misc**
- Added `src()` and `dst()` functions to the windowed edge views 

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Are there any further changes required?
