### PR TITLE
fixed NaN issue with slight change to reciprocity def

### DIFF
--- a/docbrown/db/src/algorithms/reciprocity.rs
+++ b/docbrown/db/src/algorithms/reciprocity.rs
@@ -1,10 +1,10 @@
 use crate::graph_window::{WindowedGraph, WindowedVertex};
+use crate::view_api::*;
 use std::collections::HashSet;
-use std::iter::Map;
 
 fn get_reciprocal_edge_count(v: &WindowedVertex) -> (u64,u64,u64) {
-    let out_neighbours:HashSet<u64> = v.out_neighbours_ids().filter(|x| *x != v.g_id).collect();
-    let in_neighbours:HashSet<u64>= v.in_neighbours_ids().filter(|x| *x != v.g_id).collect();
+    let out_neighbours:HashSet<u64> = v.out_neighbours().id().filter(|x| *x != v.g_id).collect();
+    let in_neighbours:HashSet<u64>= v.in_neighbours().id().filter(|x| *x != v.g_id).collect();
     (out_neighbours.len() as u64, in_neighbours.len() as u64, out_neighbours.intersection(&in_neighbours).count() as u64)
 }
 
@@ -42,6 +42,7 @@ pub fn local_reciprocity(graph: &WindowedGraph, v: u64) -> f64 {
 #[cfg(test)]
 mod reciprocity_test {
     use crate::graph::Graph;
+    use super::{all_local_reciprocity, global_reciprocity, local_reciprocity};
 
     #[test]
     fn check_all_reciprocities() {

--- a/docbrown/db/src/algorithms/reciprocity.rs
+++ b/docbrown/db/src/algorithms/reciprocity.rs
@@ -1,6 +1,3 @@
-use std::iter::Map;
-use futures::StreamExt;
-use itertools::Itertools;
 use crate::graph_window::{WindowedGraph, WindowedVertex};
 use std::collections::HashSet;
 
@@ -19,7 +16,7 @@ pub fn global_reciprocity(graph: &WindowedGraph) -> f64 {
             (acc.0 + r_e_c.0, 
              acc.1 + r_e_c.2)
         });
-    (edges.1 as f64 / edges.0 as f64)
+    edges.1 as f64 / edges.0 as f64
 }
 
 // Returns the reciprocity of every vertex in the graph as a tuple of
@@ -46,7 +43,6 @@ pub fn local_reciprocity(graph: &WindowedGraph, v: u64) -> f64 {
 
 #[cfg(test)]
 mod reciprocity_test {
-    use crate::algorithms::reciprocity;
     use crate::graph::Graph;
     use super::{local_reciprocity, all_local_reciprocity, global_reciprocity};
 
@@ -65,11 +61,11 @@ mod reciprocity_test {
         }
 
         let windowed_graph = g.window(0, 2);
-        let mut expected = 0.0;
-        let mut actual = local_reciprocity(&windowed_graph, 5);
+        let expected = 0.0;
+        let actual = local_reciprocity(&windowed_graph, 5);
         assert_eq!(actual, expected);
 
-        let mut expected: Vec<(u64, f64)> = vec![
+        let expected: Vec<(u64, f64)> = vec![
             (1, 0.4),
             (2, 2.0/3.0),
             (3, 0.5),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change to the reciprocity algo s.t. defined as 2.0* intersection(incoming neighbours, outgoing neighbours) / size of incoming + outgoing neighbours.
### Why are the changes needed?
Means that nodes with 0 outgoing edges have reciprocity of `0` rather than `NaN`.
### Does this PR introduce any user-facing change? If yes is this documented?
No.
### How was this patch tested?
Updated the test on small graphs.
### Are there any further changes required?
Could in future use definition of global reciprocity to be with respect to a random graph, perhaps have as an additional flag.