### PR TITLE
Cancels previous CI runs if you push to the same branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   call-test-rust-workflow-in-local-repo:
     name: Run Rust tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+
 jobs:
   call-test-rust-workflow-in-local-repo:
     name: Run Rust tests


### PR DESCRIPTION
### What changes were proposed in this pull request?

if you commit twice to a PR it will run all the tests, we now use alot of machines, it will run the tests twice

this will auto cancel a previous ci if u push to a branch where its already running

### Why are the changes needed?

### Does this PR introduce any user-facing change? If yes is this documented?

### How was this patch tested?

### Are there any further changes required?
